### PR TITLE
Fixes Undefined Day of the Week, datebox style fix for smaller screen

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -65,8 +65,8 @@
 			d.months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 			d.month = d.months[d.date.getMonth()];
 			d.d = d.date.getDate();
-			d.wkdys = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
-			d.dow = d.wkdys[ d.date.getDay() - 1 ];
+			d.wkdys = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+			d.dow = d.wkdys[ d.date.getDay() ];
 			d.day = (d.d > 9)? d.d : "0"+d.d;
 			d.time = formatAMPM( d.date );
 

--- a/style.css
+++ b/style.css
@@ -74,12 +74,13 @@ section {
 
 .meetup {
 	display: grid;
-	grid-template-columns: 9% repeat(6, 10%);
+	grid-template-columns: 70px repeat(6, 10%);
 	margin-bottom: 0.4rem;
 }
 
 .datebox {
 	display: table-cell;
+	min-width: 70px;
     border: 1px solid #b74949;
     margin-right: 5px;
     font-size: 13px;


### PR DESCRIPTION
Currently the days of the week array is incorrect by having Sunday at the end of the array. It should be in the first position of the array. This causes an 'Undefined' for the day of the week.