### PR TITLE
made some tune up on external links

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -26,7 +26,7 @@
 <body>
 	<header>
 		<h1>Learn Teach Code</h1>
-		<h5><a href="https://learnteachcode.org" title="Back to Homepage">Home</a> | <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" title="Link to our Slack Sign up page"  target="_blank">Join our Slack!</a> | <a href="https://github.com/LearnTeachCode/code-coffee-compendium" title="Link to our GitHub page" target="_blank">Resources</a> | <a href="./code-of-conduct.html" title="LTC Code of Conduct">Code of Conduct</a></h5>
+		<h5><a href="https://learnteachcode.org" title="Back to Homepage">Home</a> | <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" title="Link to our Slack Sign up page" target="_blank" rel="noopener">Join our Slack!</a> | <a href="https://github.com/LearnTeachCode/code-coffee-compendium" title="Link to our GitHub page" target="_blank" rel="noopener">Resources</a> | <a href="./code-of-conduct.html" title="LTC Code of Conduct">Code of Conduct</a></h5>
 	</header>
 
 	<section>
@@ -76,16 +76,16 @@
 		<p>This Code of Conduct is adapted from:</p>
 
 		<ul>
-			<li><a href="https://dev.to/code-of-conduct" title="link to dev-to coc" target="_blank">dev.to</a></li>
-			<li><a href="https://www.recurse.com/code-of-conduct" title="link to RC coc" target="_blank">Recurse Center</a></li>
-			<li><a href="https://stackoverflow.com/conduct" title="link to stackoverflow coc"target="_blank">Stack Overflow</a></li>
+			<li><a href="https://dev.to/code-of-conduct" title="link to dev-to coc" target="_blank" rel="noopener">dev.to</a></li>
+			<li><a href="https://www.recurse.com/code-of-conduct" title="link to RC coc" target="_blank" rel="noopener">Recurse Center</a></li>
+			<li><a href="https://stackoverflow.com/conduct" title="link to stackoverflow coc"target="_blank" rel="noopener">Stack Overflow</a></li>
 		</ul>
 	</section>
 
 	<footer>
 		<p>
 			<strong>Want to get more involved with our community?</strong>
-			 <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLTY5MDM1MjEwNTA4NmUzMDMwNDhlMmI2YjFhMDM1MjdhY2RmZmRlZDUyMDkxMjA0OTY5ZjNiOGE1MTE1ZmZkYzc" target="_blank">Join our chatroom on Slack</a> and follow us on <a href="https://twitter.com/LearnToCodeLA" target="_blank">Twitter</a> and <a href="https://github.com/learnteachcode" target="_blank">GitHub</a>!
+			 <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLTY5MDM1MjEwNTA4NmUzMDMwNDhlMmI2YjFhMDM1MjdhY2RmZmRlZDUyMDkxMjA0OTY5ZjNiOGE1MTE1ZmZkYzc" target="_blank" rel="noopener">Join our chatroom on Slack</a> and follow us on <a href="https://twitter.com/LearnToCodeLA" target="_blank" rel="noopener">Twitter</a> and <a href="https://github.com/learnteachcode" target="_blank" rel="noopener">GitHub</a>!
 		</p>
 		<p>
 			<strong>Want to sponsor us?</strong> We're always on the lookout for more meeting spaces. Let us know if you have any suggestions or would like to sponsor us at your office!

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -9,7 +9,9 @@
 	<title>Code of Conduct | Learn Teach Code</title>
 
 	<!-- Google Analytics - Global site tag (gtag.js) -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-118124010-1"></script>
+	<script src="https://www.googletagmanager.com/gtag/js?id=UA-118124010-1"
+	integrity="sha384-sI3LzIv9nV/RuJWbmkwmZd5qadUqvFPoLrtjRs959uhqOiJ2UZ//lAL+CMv5AyKF"
+	crossorigin="anonymous"></script>
 	<script>
 	window.dataLayer = window.dataLayer || [];
 	function gtag(){dataLayer.push(arguments);}
@@ -24,7 +26,7 @@
 <body>
 	<header>
 		<h1>Learn Teach Code</h1>
-		<h5><a href="https://learnteachcode.org" title="Back to Homepage">Home</a> | <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU">Join our Slack!</a> | <a href="https://github.com/LearnTeachCode/code-coffee-compendium">Resources</a> | <a href="./code_of_conduct.html">Code of Conduct</a></h5>
+		<h5><a href="https://learnteachcode.org" title="Back to Homepage">Home</a> | <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" title="Link to our Slack Sign up page"  target="_blank">Join our Slack!</a> | <a href="https://github.com/LearnTeachCode/code-coffee-compendium" title="Link to our GitHub page" target="_blank">Resources</a> | <a href="./code-of-conduct.html" title="LTC Code of Conduct">Code of Conduct</a></h5>
 	</header>
 
 	<section>
@@ -74,18 +76,16 @@
 		<p>This Code of Conduct is adapted from:</p>
 
 		<ul>
-			<li><a href="https://dev.to/code-of-conduct">dev.to</a></li>
-			<li><a heref="https://www.recurse.com/code-of-conduct">Recurse Center</a></li>
-			<li><a heref="https://stackoverflow.com/conduct">Stack Overflow</a</li>
-
-
+			<li><a href="https://dev.to/code-of-conduct" title="link to dev-to coc" target="_blank">dev.to</a></li>
+			<li><a href="https://www.recurse.com/code-of-conduct" title="link to RC coc" target="_blank">Recurse Center</a></li>
+			<li><a href="https://stackoverflow.com/conduct" title="link to stackoverflow coc"target="_blank">Stack Overflow</a></li>
 		</ul>
 	</section>
 
 	<footer>
 		<p>
 			<strong>Want to get more involved with our community?</strong>
-			 <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLTY5MDM1MjEwNTA4NmUzMDMwNDhlMmI2YjFhMDM1MjdhY2RmZmRlZDUyMDkxMjA0OTY5ZjNiOGE1MTE1ZmZkYzc">Join our chatroom on Slack</a> and follow us on <a href="https://twitter.com/LearnToCodeLA">Twitter</a> and <a href="https://github.com/learnteachcode">GitHub</a>!
+			 <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLTY5MDM1MjEwNTA4NmUzMDMwNDhlMmI2YjFhMDM1MjdhY2RmZmRlZDUyMDkxMjA0OTY5ZjNiOGE1MTE1ZmZkYzc" target="_blank">Join our chatroom on Slack</a> and follow us on <a href="https://twitter.com/LearnToCodeLA" target="_blank">Twitter</a> and <a href="https://github.com/learnteachcode" target="_blank">GitHub</a>!
 		</p>
 		<p>
 			<strong>Want to sponsor us?</strong> We're always on the lookout for more meeting spaces. Let us know if you have any suggestions or would like to sponsor us at your office!

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 		<h5><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank" rel="noopener">Join our Slack!</a> |<a href="https://github.com/LearnTeachCode/code-coffee-compendium" target="_blank" rel="noopener">Resources</a> | <a href="./code-of-conduct.html">Code of Conduct</a></h5>
 		<p class="tagline">A community for anyone who wants to learn about computer science or programming</p>
 		<p>Whether you're a total beginner or a coding ninja/guru/Jedi Master, we're here to learn about computer science and programming in a fun, informal environment -- and also to provide moral support to fight the fears and frustrations that come with learning a new skill or transitioning to a new career.</p>
-		<p><strong><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank" rel="noopener"</a>>Click here to join our chatroom on Slack!</a></strong></p>
+		<p><strong><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank" rel="noopener">Click here to join our chatroom on Slack!</a></strong></p>
 	</header>
 
 	<section>

--- a/index.html
+++ b/index.html
@@ -28,10 +28,10 @@
 <body>
 	<header>
 		<h1>Learn Teach Code</h1>
-		<h5><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank">Join our Slack!</a> | <a href="https://github.com/LearnTeachCode/code-coffee-compendium" target="_blank">Resources</a> | <a href="./code-of-conduct.html">Code of Conduct</a></h5>
+		<h5><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank" rel="noopener">Join our Slack!</a> |<a href="https://github.com/LearnTeachCode/code-coffee-compendium" target="_blank" rel="noopener">Resources</a> | <a href="./code-of-conduct.html">Code of Conduct</a></h5>
 		<p class="tagline">A community for anyone who wants to learn about computer science or programming</p>
 		<p>Whether you're a total beginner or a coding ninja/guru/Jedi Master, we're here to learn about computer science and programming in a fun, informal environment -- and also to provide moral support to fight the fears and frustrations that come with learning a new skill or transitioning to a new career.</p>
-		<p><strong><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank"<--!></a>>Click here to join our chatroom on Slack!</a></strong></p>
+		<p><strong><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank" rel="noopener"</a>>Click here to join our chatroom on Slack!</a></strong></p>
 	</header>
 
 	<section>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
 	<title>Learn Teach Code</title>
 
 	<!-- Google Analytics - Global site tag (gtag.js) -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-118124010-1"></script>
+	<script src="https://www.googletagmanager.com/gtag/js?id=UA-118124010-1"
+	integrity="sha384-sI3LzIv9nV/RuJWbmkwmZd5qadUqvFPoLrtjRs959uhqOiJ2UZ//lAL+CMv5AyKF"
+	crossorigin="anonymous"></script>
 	<script>
 	window.dataLayer = window.dataLayer || [];
 	function gtag(){dataLayer.push(arguments);}
@@ -26,10 +28,10 @@
 <body>
 	<header>
 		<h1>Learn Teach Code</h1>
-		<h5><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU">Join our Slack!</a> | <a href="https://github.com/LearnTeachCode/code-coffee-compendium">Resources</a> | <a href="./code_of_conduct.html">Code of Conduct</a></h5>
+		<h5><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank">Join our Slack!</a> | <a href="https://github.com/LearnTeachCode/code-coffee-compendium" target="_blank">Resources</a> | <a href="./code-of-conduct.html">Code of Conduct</a></h5>
 		<p class="tagline">A community for anyone who wants to learn about computer science or programming</p>
 		<p>Whether you're a total beginner or a coding ninja/guru/Jedi Master, we're here to learn about computer science and programming in a fun, informal environment -- and also to provide moral support to fight the fears and frustrations that come with learning a new skill or transitioning to a new career.</p>
-		<p><strong><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU">Click here to join our chatroom on Slack!</a></strong></p>
+		<p><strong><a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLThlNjQzYTMzMzEwYWU1MDhmOGUyZmJmMTllZWM3MWQ1ZGU3ZDRkYzY3ZDc3YjE2YjliMTg0MjM2ZWZiMmIwYWU" target="_blank"<--!></a>>Click here to join our chatroom on Slack!</a></strong></p>
 	</header>
 
 	<section>
@@ -77,14 +79,16 @@
 	<footer>
 		<p>
 			<strong>Want to get more involved with our community?</strong>
-			 <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLTY5MDM1MjEwNTA4NmUzMDMwNDhlMmI2YjFhMDM1MjdhY2RmZmRlZDUyMDkxMjA0OTY5ZjNiOGE1MTE1ZmZkYzc">Join our chatroom on Slack</a> and follow us on <a href="https://twitter.com/LearnToCodeLA">Twitter</a> and <a href="https://github.com/learnteachcode">GitHub</a>!
+			 <a href="https://join.slack.com/t/learnteachcode/shared_invite/enQtNDQ2MTM3NTk3MjMyLTY5MDM1MjEwNTA4NmUzMDMwNDhlMmI2YjFhMDM1MjdhY2RmZmRlZDUyMDkxMjA0OTY5ZjNiOGE1MTE1ZmZkYzc" target="_blank">Join our chatroom on Slack</a> and follow us on <a href="https://twitter.com/LearnToCodeLA" target="_blank">Twitter</a> and <a href="https://github.com/learnteachcode" target="_blank">GitHub</a>!
 		</p>
 		<p>
 			<strong>Want to sponsor us?</strong> We're always on the lookout for more meeting spaces. Let us know if you have any suggestions or would like to sponsor us at your office!
 		</p>
 	</footer>
 	
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"
+	integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f"
+	crossorigin="anonymous"></script>
 	<script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"
 	integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg=="
 	crossorigin=""></script>


### PR DESCRIPTION
It's always nice to open external links to their own browser tab so that the user will remain on LTC website with exception of the one that links to the meetup page.
Few external JS library links didn't have hash integrity. Added them for security.
RC and SOF Code of Conduct links where not active since there was a minor typo of `heref ` instead of `href`